### PR TITLE
Bugfix/signal cli 0 10 3

### DIFF
--- a/config_default.ini
+++ b/config_default.ini
@@ -20,7 +20,7 @@ signalconfigpath = $HOME/.local/share/signal-cli/
 mailfrom = "{senderName}" <sender@mail.com>
 mailsubject = Forwarded Signal Message from "{senderName}"
 # Header-line injected at the top in the body
-bodyheading = New Signal message from {senderName} ({senderId}), sent {timestamp}
+bodyheading = New Signal message from {senderName} ({senderId}), sent {timestamp}:
 # Signature to be added at the bottom. Missing signature can lead to
 # the problem that the mailing list signatures of list traffic are not
 # automatically removed when replying.

--- a/config_default.ini
+++ b/config_default.ini
@@ -50,3 +50,8 @@ autoattach =
 +441234567890 = UK Contact
 +33123456789 = My French Friend
 +4<-startlikethis = This is Me!
+
+[EXCLUDE]
+# excluded contacts, can be used to break circular forwarding from Signal to mailing-list to Signal to mailing-list ...
++4<-startlikethis = This is Me! The name is optional
++1234567

--- a/config_default.ini
+++ b/config_default.ini
@@ -16,8 +16,15 @@ signal_cli_path = /usr/local/bin/signal-cli
 signalconfigpath = $HOME/.local/share/signal-cli/
 
 [MAIL]
-mailfrom = sender@mail.com
-mailsubject = new Signal message
+# From-header, with optional interpolation of sender-name, sender-id, timestamp, group-name, group-id
+mailfrom = "{senderName}" <sender@mail.com>
+mailsubject = Forwarded Signal Message from "{senderName}"
+# Header-line injected at the top in the body
+bodyheading = New Signal message from {senderName} ({senderId}), sent {timestamp}
+# Signature to be added at the bottom. Missing signature can lead to
+# the problem that the mailing list signatures of list traffic are not
+# automatically removed when replying.
+mailsignature = Signal Forwarding Bot for {senderName} ({senderId})
 addr_list = receiver1@mail.com,receiver2@mail.com
 smtpserver = smtp.mailserver.org
 #change port number as needed; default is 587:
@@ -36,6 +43,7 @@ X-Signal-Group-Id = {groupId}
 X-Signal-Group-Name = {groupName}
 
 [OTHER]
+timeformat = %%Y-%%m-%%d %%H:%%M:%%S %%Z
 # Text to automatically send in reply to each incoming Signal
 # message. Leave empty to disable this feature.
 autoreply =

--- a/config_default.ini
+++ b/config_default.ini
@@ -9,6 +9,8 @@ APIV2 = True # or False ...
 
 [SIGNAL]
 signalnumber = +4<-startlikethis
+# display name of signalnumber if not otherwise configured
+signalname = "Signal Email Gateway"
 signal_cli_path = /usr/local/bin/signal-cli
 # path of user's signal data directory:
 signalconfigpath = $HOME/.local/share/signal-cli/
@@ -43,6 +45,7 @@ autoattach =
 [CONTACTS]
 #you can get a list of your contacts using the command: 
 # ./signal-cli listContacts|sed s/^Number:\ //|sed s/\ Name:\ /=/|sed s/\ Blocked.*//
+# NOTE: the display names override names already set in the DBUS service
 +12125551212 = Winnie the Pooh
 +441234567890 = UK Contact
 +33123456789 = My French Friend

--- a/config_default.ini
+++ b/config_default.ini
@@ -5,10 +5,10 @@ sendmail = True
 deleteattachments = True
 # use session DBus (set to False to use system DBus)
 sessiondbus = True
+APIV2 = True # or False ...
 
 [SIGNAL]
 signalnumber = +4<-startlikethis
-signalgroupid = something like df99Z/uCOr8QsGfXIy76wQ==
 signal_cli_path = /usr/local/bin/signal-cli
 # path of user's signal data directory:
 signalconfigpath = $HOME/.local/share/signal-cli/
@@ -25,17 +25,25 @@ smtppassword = smtp password
 # in MByte:
 max_attachmentsize = 5
 
+# additional headers to add
+[HEADERS]
+X-Signal-Forwarded = +4915792396308
+X-Signal-Sender-Id = {senderId}
+X-Signal-Sender-Name = {senderName}
+X-Signal-Group-Id = {groupId}
+X-Signal-Group-Name = {groupName}
+
 [OTHER]
-#text to automatically send in reply to each incoming Signal message
-autoreply = ""
-#file to automatically attach to autoreply
-autoattach = ""
+# Text to automatically send in reply to each incoming Signal
+# message. Leave empty to disable this feature.
+autoreply =
+# file to automatically attach to autoreply
+autoattach =
 
 [CONTACTS]
 #you can get a list of your contacts using the command: 
 # ./signal-cli listContacts|sed s/^Number:\ //|sed s/\ Name:\ /=/|sed s/\ Blocked.*//
-
-+12125551212=Winnie the Pooh
-+441234567890=UK Contact
-+33123456789=My French Friend
-
++12125551212 = Winnie the Pooh
++441234567890 = UK Contact
++33123456789 = My French Friend
++4<-startlikethis = This is Me!

--- a/signalmail.py
+++ b/signalmail.py
@@ -567,7 +567,7 @@ def get_attachmentRemoteName(rawAttachment):
     return
 @get_attachmentRemoteName.register
 def _(arg: dict, verbose=False):
-    attachmentRemoteName = arg["remoteId"]
+    attachmentRemoteName = arg["fileName"]
     return attachmentRemoteName
 @get_attachmentRemoteName.register
 def _(arg: tuple, verbose=False):

--- a/signalmail.py
+++ b/signalmail.py
@@ -167,6 +167,11 @@ try:
     contacts = config.items("CONTACTS")
 except KeyError: True
 
+exclude = []
+try:
+    exclude = config.items("EXCLUDE")
+except KeyError: True
+
 headers = []
 try:
     headers = config.items("HEADERS")
@@ -253,6 +258,10 @@ def msgRcvV2 (timestamp, sender, groupId, message, extras):
     global APIV2
     APIV2 = True
     if debug: print("msgRcvV2 called")
+
+    if sender in config["EXCLUDE"]:
+        if debug: print('DEBUG - excluding ' + sender)
+        return
 
     # de- and encode some of the given arguments to more convenient formats
     mentionList = extras.get("mentions", [])

--- a/signalmail.py
+++ b/signalmail.py
@@ -233,6 +233,7 @@ def main():
     signal_client.onReceiptReceived = rcptRcv
     signal_client.onReceiptReceivedV2 = rcptRcvV2
     signal_client.onSyncMessageReceived = syncRcv
+    signal_client.onSyncMessageReceivedV2 = syncRcvV2
 
     loop.run()
 
@@ -360,12 +361,19 @@ def rcptRcv (timestamp, sender):
         print (sender)
     return
 
-def rcptRcvV2 (timestamp, sender, isDelivery, isRead, isViewed):
+#
+# type parameter
+# - read
+# - viewed
+# - delivery
+# - unknown
+#
+def rcptRcvV2 (timestamp, sender, type, extras):
     global APIV2
     APIV2 = True
     if debug:
         print ("rcptRcvV2 called")
-        print("timestamp: ", timestamp, " sender: ", sender, " isDelivery: ", isDelivery, " isRead: ", isRead, " isViewed: ", isViewed)
+        print("timestamp: ", timestamp, ", sender: ", sender, ", type: ", type, ", extras: ", extras)
     return
 
 def syncRcv (timestamp, sender, destination, groupId, message, attachmentList):
@@ -376,7 +384,7 @@ def syncRcv (timestamp, sender, destination, groupId, message, attachmentList):
         print (sender)
     return
 
-def syncRcvV2 (timestamp, sender, destination, groupId, message, mentionList, attachmentList):
+def syncRcvV2 (timestamp, sender, destination, groupId, message, extras):
     global APIV2
     APIV2 = True
     if debug:


### PR DESCRIPTION
Hi,
thank you for this script. As mentioned in #1 the current code-base does no longer work with the current version of signal-cli, which is v0.10.3 at this time.

I have also added some other features, which are described in the commits. Most  important fix is the handling of the mention- and attachment-lists which now come as Py-dicts, and the parameters of the `onMessageReceivedV2` handler (one extra dict-arg which contains attachments, mentions and other things).

Also added:
- configurable custom headers
- interpolation of group/sender name/id in custom-headers, subject- and from-headers
- retrieval of group-name form DBUS service
- sync of contact-names to DBUS service (perhaps one might want to make this an option)

It would be nice if you could consider this PR for merging. 

Just do give an idea why I stumbled over your script:

I plan to use the script in order to "synchronize" a mailing list with a Signal-group. So this signalmail is the Signal -> Email part of the story. The idea is forward the email to a dedicated account which parses the headers and then uses email-filters (sieve) to decide where to forward the message to. So this is the use for the custom headers.

The other part Email-list -> Signal remains to be written. But there are examples. Also here is the plan to pipe the list-traffic to the same dedicated email-account (as virtual email-list member) which then runs some scripts and forwards the email contents to signal groups as necessary, avoiding recursion of course.

